### PR TITLE
Ensure Vercel uses Node.js 20 runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/**/*.{js,ts}": {
+      "runtime": "nodejs20.x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add vercel.json configuration that pins API functions to the Node.js 20 runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc1f02eb108331bd198aa7fe789cd5