### PR TITLE
Update Credo link and disable Bank of Georgia

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,39 @@
         outline: none;
       }
 
+      .btn--apple {
+        background: #000000;
+        color: #ffffff;
+        border-color: #000000;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+      }
+
+      .btn--apple .btn__note {
+        color: #e8e8e8;
+      }
+
+      .btn--disabled,
+      .btn--disabled:hover,
+      .btn--disabled:focus-visible {
+        background: #e6e0d8;
+        border-color: #d6cec4;
+        color: #77736d;
+        box-shadow: none;
+        cursor: not-allowed;
+      }
+
+      .btn--disabled .btn__note {
+        color: #77736d;
+      }
+
+      .btn--apple:hover,
+      .btn--apple:focus-visible {
+        background: #111111;
+        border-color: #111111;
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.24);
+        color: #ffffff;
+      }
+
       .modal-overlay {
         position: fixed;
         inset: 0;
@@ -307,13 +340,19 @@
           <span class="btn__label" id="tbc-label">Пожертвовать лари на TBC</span>
           <span class="btn__note" id="tbc-note">в один клик</span>
         </a>
-        <a class="btn" id="bog-button" href="#">
-          <span class="btn__label" id="bog-label">Пожертвовать лари на Bank of Georgia</span>
-          <span class="btn__note" id="bog-note">по реквизитам</span>
+        <a class="btn btn--disabled" id="bog-button" aria-disabled="true" tabindex="-1">
+          <span class="btn__label" id="bog-label">Bank of Georgia</span>
+          <span class="btn__note" id="bog-note">временно не работает</span>
         </a>
-        <a class="btn" id="credo-button" href="#">
-          <span class="btn__label" id="credo-label">Пожертвовать лари на Credo</span>
-          <span class="btn__note" id="credo-note">по реквизитам</span>
+        <a
+          class="btn btn--apple"
+          id="credo-button"
+          href="https://moneypot.mycredo.ge/?publicId=707d7ade-9d47-43bb-9625-690fe0653807"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span class="btn__label" id="credo-label">Credo и Apple Pay</span>
+          <span class="btn__note" id="credo-note">онлайн оплата</span>
         </a>
         <a class="btn" id="sbp-link" href="#">
           <span class="btn__label" id="sbp-label">Пожертвовать рубли по СБП</span>
@@ -359,11 +398,9 @@
         <ul class="modal__list">
           <li id="bog-receiver">Получатель: Stanislav</li>
           <li id="bog-bank">Банк: Bank of Georgia</li>
-          <li id="bog-iban">IBAN: GE64BG0000000611135063</li>
           <li id="bog-purpose">Назначение платежа: пожертвование храму</li>
         </ul>
         <div class="modal__actions">
-          <button class="btn btn--primary" type="button" id="copy-bog">Скопировать реквизиты</button>
           <button class="btn" type="button" id="close-bog">Закрыть</button>
         </div>
       </div>
@@ -417,7 +454,6 @@
       const SBP_LINK = "https://finance.ozon.ru/apps/sbp/ozonbankpay/019b7357-1f94-79b2-8448-8b0f55d2915d"; // Реальная ссылка для оплаты по СБП
       const BOG_RECEIVER = "Stanislav"; // Получатель Bank of Georgia
       const BOG_BANK = "Bank of Georgia"; // Банк для платежа
-      const BOG_IBAN = "GE64BG0000000611135063"; // IBAN для Bank of Georgia
       const BOG_PURPOSE_RU = "пожертвование храму"; // Назначение платежа Bank of Georgia (RU)
       const BOG_PURPOSE_EN = "donation to the temple"; // Назначение платежа Bank of Georgia (EN)
       const CREDO_RECEIVER = "Anatolii Smolin"; // Укажите фактического получателя, если изменится
@@ -439,8 +475,8 @@
             "Если вы хотите принять финансовое участие в жизни храма, вы можете выбрать удобный для вас способ для пожертвований.",
           buttons: {
             tbc: { label: "Пожертвовать лари на TBC", note: "в один клик" },
-            bog: { label: "Пожертвовать лари на Bank of Georgia", note: "по реквизитам" },
-            credo: { label: "Пожертвовать лари на Credo", note: "по реквизитам" },
+            bog: { label: "Bank of Georgia", note: "временно не работает" },
+            credo: { label: "Credo и Apple Pay", note: "онлайн оплата" },
             sbp: { label: "Пожертвовать рубли по СБП", note: "в один клик" },
             crypto: { label: "Пожертвовать криптовалюту" },
             question: { label: "Задать вопрос" },
@@ -448,10 +484,8 @@
           bogTitle: "Реквизиты Bank of Georgia",
           bogReceiverLabel: "Получатель:",
           bogBankLabel: "Банк:",
-          bogIbanLabel: "IBAN:",
           bogPurposeLabel: "Назначение платежа:",
           bogPurposeValue: BOG_PURPOSE_RU,
-          bogCopy: "Скопировать реквизиты",
           credoTitle: "Реквизиты Credo Bank",
           credoReceiverLabel: "Получатель:",
           credoBankLabel: "Банк:",
@@ -483,8 +517,8 @@
             "If you would like to support the temple, please choose the most convenient donation method.",
           buttons: {
             tbc: { label: "Donate GEL via TBC", note: "one click" },
-            bog: { label: "Donate GEL via Bank of Georgia", note: "bank details" },
-            credo: { label: "Donate GEL via Credo", note: "bank details" },
+            bog: { label: "Bank of Georgia", note: "temporarily unavailable" },
+            credo: { label: "Credo & Apple Pay", note: "online payment" },
             sbp: { label: "Donate RUB via SBP", note: "one click" },
             crypto: { label: "Donate cryptocurrency" },
             question: { label: "Ask a question" },
@@ -492,10 +526,8 @@
           bogTitle: "Bank of Georgia details",
           bogReceiverLabel: "Recipient:",
           bogBankLabel: "Bank:",
-          bogIbanLabel: "IBAN:",
           bogPurposeLabel: "Payment purpose:",
           bogPurposeValue: BOG_PURPOSE_EN,
-          bogCopy: "Copy details",
           credoTitle: "Credo Bank details",
           credoReceiverLabel: "Recipient:",
           credoBankLabel: "Bank:",
@@ -535,10 +567,8 @@
       const bogModal = document.getElementById("bog-modal");
       const bogModalClose = document.getElementById("bog-modal-close");
       const bogModalCloseSecondary = document.getElementById("close-bog");
-      const copyBogButton = document.getElementById("copy-bog");
       const bogReceiver = document.getElementById("bog-receiver");
       const bogBank = document.getElementById("bog-bank");
-      const bogIban = document.getElementById("bog-iban");
       const bogPurpose = document.getElementById("bog-purpose");
       const credoButton = document.getElementById("credo-button");
       const credoLabel = document.getElementById("credo-label");
@@ -644,10 +674,8 @@
         if (bogModalTitle) bogModalTitle.textContent = t.bogTitle;
         if (bogModal) bogModal.setAttribute("aria-label", t.bogTitle);
         if (bogModalCloseSecondary) bogModalCloseSecondary.textContent = t.close;
-        if (copyBogButton) copyBogButton.textContent = t.bogCopy;
         if (bogReceiver) bogReceiver.textContent = `${t.bogReceiverLabel} ${BOG_RECEIVER}`;
         if (bogBank) bogBank.textContent = `${t.bogBankLabel} ${BOG_BANK}`;
-        if (bogIban) bogIban.textContent = `${t.bogIbanLabel} ${BOG_IBAN}`;
         if (bogPurpose) bogPurpose.textContent = `${t.bogPurposeLabel} ${t.bogPurposeValue}`;
         if (credoModalTitle) credoModalTitle.textContent = t.credoTitle;
         if (credoReceiver) credoReceiver.textContent = `${t.credoReceiverLabel} ${CREDO_RECEIVER}`;
@@ -744,17 +772,9 @@
         }
       };
 
-      if (credoButton) {
-        credoButton.addEventListener("click", (event) => {
-          event.preventDefault();
-          openCredoModal();
-        });
-      }
-
       if (bogButton) {
         bogButton.addEventListener("click", (event) => {
           event.preventDefault();
-          openBogModal();
         });
       }
 
@@ -847,14 +867,6 @@
       if (copyCredoButton) {
         copyCredoButton.addEventListener("click", () => {
           navigator.clipboard.writeText(CREDO_IBAN).then(() => {
-            showCopyNote(getText("copyThanks"));
-          });
-        });
-      }
-
-      if (copyBogButton) {
-        copyBogButton.addEventListener("click", () => {
-          navigator.clipboard.writeText(BOG_IBAN).then(() => {
             showCopyNote(getText("copyThanks"));
           });
         });


### PR DESCRIPTION
### Motivation

- Update the Credo donation flow to use the new MoneyPot `publicId` and present it as an Apple Pay-styled button, and mark Bank of Georgia as temporarily unavailable while removing its exposed account number and copy action.

### Description

- Change the Credo button `href` to `https://moneypot.mycredo.ge/?publicId=707d7ade-9d47-43bb-9625-690fe0653807` and keep it opening in a new tab with the Apple-style `btn--apple` class and label `Credo и Apple Pay`.
- Replace the Bank of Georgia action with a disabled button (removed `href`, added `aria-disabled="true"` and `tabindex="-1"`) and update its note to `временно не работает` (also updated English text to `temporarily unavailable`).
- Remove the Bank of Georgia IBAN and the `Скопировать реквизиты` button and delete related JS constants/DOM lookups and the copy handler to avoid exposing the account while the option is disabled.
- Add `.btn--disabled` CSS and adjust hover/CSS ordering to ensure Apple-style and disabled styles render correctly and prevent the Bank of Georgia click from opening the modal (listener now only prevents default).

### Testing

- Ran JavaScript syntax check with `node --check /tmp/index-script.js` and it succeeded.
- Performed an HTML smoke check with `python3` using `html.parser` and it succeeded.
- Verified string removals/changes with `rg` (checked for old Credo id and Bank of Georgia IBAN) and the expected identifiers are no longer present.
- Visual/browser tests were not run because a headless browser (Chromium/Playwright) was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6958a25877188331aff1ddef861c377b)